### PR TITLE
Add TypeScript typings. Fixes #2

### DIFF
--- a/bin/ts-test
+++ b/bin/ts-test
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+echo "Here's how (typed!) success looks and how fast it is"
+time ./node_modules/.bin/ts-node ./node_modules/.bin/teenytest test-types.ts#pass
+
+echo "Here's how (typed!) failure looks and how fast it is"
+time ./node_modules/.bin/ts-node ./node_modules/.bin/teenytest test-types.ts#fail
+
+echo "Here's what type errors look like"
+time ./node_modules/.bin/ts-node ./node_modules/.bin/teenytest test-type-error.ts
+
+last_exit=$?
+if [[ $last_exit = 0 ]]; then
+  echo "Wups it didn't fail as expected"
+  exit 1
+else
+  exit 0
+fi
+

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,4 +6,8 @@ export function equal<T>(actual: T, expected: T, msg?: string): void;
 
 export function notEqual<T>(actual: T, expected: T, msg?: string): void;
 
-export function config(userConfig: object): object;
+interface UserConfig {
+  color: boolean;
+}
+
+export function config(userConfig: UserConfig): UserConfig;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,9 @@
+// Type definitions for ought 0.0.4
+// Project: https://github.com/testdouble/ought
+// TypeScript version: 3.3.3
+
+export function equal<T>(actual: T, expected: T, msg?: string): void;
+
+export function notEqual<T>(actual: T, expected: T, msg?: string): void;
+
+export function config(userConfig: object): object;

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,12 @@
         "color-convert": "^1.9.0"
       }
     },
+    "arg": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.0.tgz",
+      "integrity": "sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg==",
+      "dev": true
+    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -141,6 +147,12 @@
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
+    },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
     },
     "caller-path": {
       "version": "0.1.0",
@@ -323,6 +335,12 @@
           "dev": true
         }
       }
+    },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true
     },
     "doctrine": {
       "version": "2.1.0",
@@ -1131,6 +1149,12 @@
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
+    "make-error": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
+      "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==",
+      "dev": true
+    },
     "md5-hex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-2.0.0.tgz",
@@ -1599,6 +1623,22 @@
         "is-fullwidth-code-point": "^2.0.0"
       }
     },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
+    },
+    "source-map-support": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.10.tgz",
+      "integrity": "sha512-YfQ3tQFTK/yzlGJuX8pTwa4tifQj4QS2Mj7UegOu8jAz59MqIiMGPXxQhVQiIMNzayuUSF/jEuVnfFF5JqybmQ==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
     "spdx-correct": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
@@ -1774,6 +1814,19 @@
         "os-tmpdir": "~1.0.2"
       }
     },
+    "ts-node": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.0.2.tgz",
+      "integrity": "sha512-MosTrinKmaAcWgO8tqMjMJB22h+sp3Rd1i4fdoWY4mhBDekOwIAKI/bzmRi7IcbCmjquccYg2gcF6NBkLgr0Tw==",
+      "dev": true,
+      "requires": {
+        "arg": "^4.1.0",
+        "diff": "^3.1.0",
+        "make-error": "^1.1.1",
+        "source-map-support": "^0.5.6",
+        "yn": "^3.0.0"
+      }
+    },
     "type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
@@ -1782,6 +1835,12 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
+    },
+    "typescript": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.3.tgz",
+      "integrity": "sha512-Y21Xqe54TBVp+VDSNbuDYdGw0BpoR/Q6wo/+35M8PAU0vipahnyduJWirxxdxjsAkS7hue53x2zp8gz7F05u0A==",
+      "dev": true
     },
     "uniq": {
       "version": "1.0.1",
@@ -1847,6 +1906,12 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+      "dev": true
+    },
+    "yn": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.0.0.tgz",
+      "integrity": "sha512-+Wo/p5VRfxUgBUGy2j/6KX2mj9AYJWOHuhMjMcbBFc3y54o9/4buK1ksBvuiK01C3kby8DH9lSmJdSxw+4G/2Q==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "ought",
   "version": "0.0.4",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "test": "standard --fix && bin/test"
   },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "main": "index.js",
   "types": "index.d.ts",
   "scripts": {
-    "test": "standard --fix && bin/test"
+    "test": "standard --fix && bin/test",
+    "test-types": "bin/ts-test"
   },
   "keywords": [
     "assert",
@@ -20,7 +21,9 @@
   },
   "devDependencies": {
     "standard": "^12.0.1",
-    "teenytest": "^5.1.1"
+    "teenytest": "^5.1.1",
+    "ts-node": "^8.0.2",
+    "typescript": "^3.3.3"
   },
   "directories": {
     "lib": "lib"

--- a/test-type-error.ts
+++ b/test-type-error.ts
@@ -1,0 +1,11 @@
+import * as ought from "./index";
+
+export = {
+  typeMismatch() {
+    ought.equal(42, "42");
+  },
+
+  unimplementedInterface() {
+    ought.config({});
+  }
+};

--- a/test-types.ts
+++ b/test-types.ts
@@ -1,0 +1,12 @@
+import * as ought from "./index";
+
+export = {
+  fail() {
+    ought.equal(7, 11);
+  },
+
+  pass() {
+    ought.equal(42, 42);
+    ought.config({ color: false });
+  }
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es5",
+    "lib": ["es5"],
+    "forceConsistentCasingInFileNames": true,
+    "noImplicitAny": true,
+    "noImplicitThis":, true,
+    "strictNullChecks": true
+  },
+  "exclude": [
+    "node_modules"
+  ],
+  "files": [
+    "index.d.ts"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,10 +3,7 @@
     "module": "commonjs",
     "target": "es5",
     "lib": ["es5"],
-    "forceConsistentCasingInFileNames": true,
-    "noImplicitAny": true,
-    "noImplicitThis":, true,
-    "strictNullChecks": true
+    "strict": true
   },
   "exclude": [
     "node_modules"


### PR DESCRIPTION
I'm new enough to TypeScript that I'm _fairly_ sure this is the right direction, but not at all convinced. (I actually had a tougher time with the `export`/`import`s than the actual type annotations.)

Some thoughts:

1. It's not immediately clear to me if this is fine as-is or if I should introduce a [namespace or module](https://www.typescriptlang.org/docs/handbook/namespaces-and-modules.html). I tried exporting a namespace, but this caused namespace resolution issues in the generated JS, so I've left them out for now (it's super possible I was making a rookie mistake).
2. I'm not quite sure the best way to test this. I made a sample test `.ts` file (see below) that uses these annotations and got the correct breakages when I intentionally broke the type annotations, but I'm not sure this is enough; it might be better for me to create a skeleton TypeScript project and use `ought` to test it.
3. I took a stab at reasonable-looking options for the `tsconfig.json` based on [the documentation](https://www.typescriptlang.org/docs/handbook/compiler-options.html), but happy to make changes if these are too strict or if there's something I'm missing.

Tested with the following (version 3.3.3 of TS, 10.15.1 of Node):

## Happy Path: Passing Tests
```ts
import * as ought from "./index";

ought.equal(42, 42);
ought.notEqual(7, 11);
console.log(ought.config({ color: false }));
```
![tests pass](https://d12c9k59mfk1gc.cloudfront.net/items/3z272W2m0r0t2m3n3N18/happy_path.png?v=2e7961a6)

## Sad Path: Type Mismatch
```ts
import * as ought from "./index";

ought.equal(42, '42');
ought.notEqual(7, 11);
console.log(ought.config({ color: false }));
```
![type mismatch](https://d12c9k59mfk1gc.cloudfront.net/items/1p3w2d1k2x0L3u3G1k0c/sad_path_type.png?v=fa5009ab)

## Sad Path: Failed Test
```ts
import * as ought from "./index";

ought.equal(42, 7);
ought.notEqual(7, 11);
console.log(ought.config({ color: false }));
```
![failed test](https://d12c9k59mfk1gc.cloudfront.net/items/2A0o3v3m3a2m3x031n1R/sad_path_failed_test.png?v=ddf7c0b7)

CC @garybernhardt (no rush!)